### PR TITLE
fix order of sourceTalkback and sink terminations

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ const take = max => source => (start, sink) => {
         sink(t, d);
         if (taken === max && !end) {
           end = true
-          sink(2);
           sourceTalkback(2);
+          sink(2);
         }
       }
     } else {


### PR DESCRIPTION
if `take` is the origin of termination, then the upstream source should be terminated before the downstream sink
without this, concat-map and others relying on termination signals will move on, and cause race condition issues

fixes #6 